### PR TITLE
Add support for proper Gradle up-to-date checks

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -17,6 +17,7 @@
 apply plugin: 'groovy'
 apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.bintray'
+apply plugin: 'java-gradle-plugin'
 
 def pluginVersion = '0.7.0'
 
@@ -104,4 +105,7 @@ dependencies {
     compile localGroovy()
 
     compile 'org.javassist:javassist:3.20.0-GA'
+
+    testCompile 'junit:junit:4.12'
+    testCompile gradleTestKit()
 }

--- a/buildSrc/src/main/java/de/mobilej/UnMockTask.java
+++ b/buildSrc/src/main/java/de/mobilej/UnMockTask.java
@@ -1,0 +1,126 @@
+/*
+   Copyright (C) 2015 Björn Quentin
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+package de.mobilej;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.File;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Gradle task to handle unmocking.
+ *
+ * Actual work is delegated to {@link ProcessRealAndroidJar} but this task handles defining all inputs
+ * and outputs so Gradle can do proper up-to-date checking and only run the task when necessary.
+ */
+@CacheableTask
+public class UnMockTask extends DefaultTask {
+
+    private File allAndroid;
+    private File outputDir;
+    private File unmockedOutputJar;
+    private List<String> keepClasses;
+    private List<String> renameClasses;
+    private List<String> delegateClasses;
+
+    @InputFile
+    public File getAllAndroid() {
+        return allAndroid;
+    }
+
+    public void setAllAndroid(File allAndroid) {
+        this.allAndroid = allAndroid;
+    }
+
+    @OutputDirectory
+    public File getOutputDir() {
+        return outputDir;
+    }
+
+    public void setOutputDir(File outputDir) {
+        this.outputDir = outputDir;
+    }
+
+    @OutputFile
+    public File getUnmockedOutputJar() {
+        return unmockedOutputJar;
+    }
+
+    public void setUnmockedOutputJar(File unmockedOutputJar) {
+        this.unmockedOutputJar = unmockedOutputJar;
+    }
+
+    @Input
+    public List<String> getKeepClasses() {
+        return keepClasses;
+    }
+
+    public void setKeepClasses(List<String> keepClasses) {
+        this.keepClasses = keepClasses;
+    }
+
+    @Input
+    public List<String> getRenameClasses() {
+        return renameClasses;
+    }
+
+    public void setRenameClasses(List<String> renameClasses) {
+        this.renameClasses = renameClasses;
+    }
+
+    @Input
+    public List<String> getDelegateClasses() {
+        return delegateClasses;
+    }
+
+    public void setDelegateClasses(List<String> delegateClasses) {
+        this.delegateClasses = delegateClasses;
+    }
+
+    @TaskAction
+    public void unmock() {
+        requireNonNull(allAndroid, "Missing android-all.jar file required for unmocking");
+        requireNonNull(outputDir, "No output directory provided for UnMockTask");
+        requireNonNull(unmockedOutputJar, "No output file name provided for UnMockTask");
+        requireNonNull(keepClasses, "UnMock keep class list cannot be null");
+        requireNonNull(renameClasses, "UnMock rename class list cannot be null");
+        requireNonNull(delegateClasses, "UnMock delegate class list cannot be null");
+
+        try {
+            ProcessRealAndroidJar.process(
+                    allAndroid,
+                    outputDir,
+                    unmockedOutputJar,
+                    keepClasses.toArray(new String[0]),
+                    renameClasses.toArray(new String[0]),
+                    delegateClasses.toArray(new String[0]),
+                    getProject().getLogger()
+            );
+        } catch (Exception e) {
+            throw new GradleException("Exception while unmocking", e);
+        }
+    }
+}

--- a/buildSrc/src/test/java/de/mobilej/UnMockTaskTest.java
+++ b/buildSrc/src/test/java/de/mobilej/UnMockTaskTest.java
@@ -1,0 +1,191 @@
+/*
+   Copyright (C) 2015 Björn Quentin
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+package de.mobilej;
+
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.gradle.util.GFileUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+
+import static org.gradle.util.GFileUtils.writeFile;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+
+public class UnMockTaskTest {
+
+    @Rule
+    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+
+    private File buildGradle;
+
+    private static final String BUILD_GRADLE_CONTENTS = ""
+        + "plugins { id 'de.mobilej.unmock' apply false }\n"
+        + "\n"
+        + "repositories {\n"
+        + "    jcenter()\n"
+        + "}"
+        + "\n"
+        // Since we're not adding AGP as a dependency, we need to create this configuration manually for things to work
+        + "configurations { testImplementation }"
+        + "\n"
+        + "apply plugin: 'de.mobilej.unmock'"
+        + "\n"
+        + "dependencies {\n"
+        + "    unmock 'org.robolectric:android-all:7.1.0_r7-robolectric-0'\n"
+        + "}\n"
+        + "\n"
+        + "unMock {\n"
+        + "    keep \"android.widget.BaseAdapter\"\n"
+        + "    keep \"android.widget.ArrayAdapter\"\n"
+        + "    keep \"android.os.Bundle\"\n"
+        + "    keepStartingWith \"android.database.MatrixCursor\"\n"
+        + "    keep \"android.database.AbstractCursor\"\n"
+        + "    keep \"android.database.CrossProcessCursor\"\n"
+        + "    keepStartingWith \"android.text.TextUtils\"\n"
+        + "    keepStartingWith \"android.util.\"\n"
+        + "    keepStartingWith \"android.text.\"\n"
+        + "    keepStartingWith \"android.content.ContentValues\"\n"
+        + "    keepStartingWith \"android.content.ComponentName\"\n"
+        + "    keepStartingWith \"android.content.ContentUris\"\n"
+        + "    keepStartingWith \"android.content.ContentProviderOperation\"\n"
+        + "    keepStartingWith \"android.content.ContentProviderResult\"\n"
+        + "    keepStartingWith \"android.content.UriMatcher\"\n"
+        + "    keepStartingWith \"android.content.Intent\"\n"
+        + "    keep \"android.location.Location\"\n"
+        + "    keepStartingWith \"android.content.res.Configuration\"\n"
+        + "    keepStartingWith \"org.\"\n"
+        + "    keepStartingWith \"libcore.\"\n"
+        + "    keepStartingWith \"com.android.internal.R\"\n"
+        + "    keepStartingWith \"com.android.internal.util.\"\n"
+        + "    keep \"android.net.Uri\"\n"
+        + "\n"
+        + "    keepAndRename \"java.nio.charset.Charsets\" to \"xjava.nio.charset.Charsets\"\n"
+        + "\n"
+        + "    keepStartingWith \"android.icu.\"\n"
+        + "}\n";
+
+    @Before
+    public void setup() throws Exception {
+        buildGradle = testProjectDir.newFile("build.gradle");
+        writeFile(BUILD_GRADLE_CONTENTS, buildGradle);
+
+        File localBuildCacheDirectory = testProjectDir.newFolder("local-cache");
+        File settingsGradle = testProjectDir.newFile("settings.gradle");
+        writeFile("buildCache {\n"
+                      + "    local {\n"
+                      + "        directory '" + localBuildCacheDirectory.toURI() + "'\n"
+                      + "    }\n"
+                      + "}\n", settingsGradle);
+    }
+
+    @Test
+    public void canAddTaskToProject() {
+        Project project = ProjectBuilder.builder().build();
+        Task task = project.getTasks().create("unMock", UnMockTask.class);
+        assertNotNull(task);
+    }
+
+    @Test
+    public void unMockTaskPassesOnce() {
+        BuildResult result = newGradleRunner().build();
+
+        assertSame(result.task(":unMock").getOutcome(), TaskOutcome.SUCCESS);
+    }
+
+    @Test
+    public void unMockTaskIsUpToDateOnSecondRun() {
+        BuildResult firstResult = newGradleRunner().build();
+        BuildResult secondResult = newGradleRunner().build();
+
+        assertSame(firstResult.task(":unMock").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(secondResult.task(":unMock").getOutcome(), TaskOutcome.UP_TO_DATE);
+    }
+
+    @Test
+    public void unMockTaskIsNotUpToDateIfNewKeepClassAdded() {
+        BuildResult firstResult = newGradleRunner().build();
+
+        assertSame(firstResult.task(":unMock").getOutcome(), TaskOutcome.SUCCESS);
+
+        writeFile(BUILD_GRADLE_CONTENTS
+                      + "unMock {\n"
+                      + "    keep \"android.net.Uri\"\n"
+                      + "}",
+                  buildGradle);
+
+        BuildResult secondResult = newGradleRunner().build();
+
+        assertSame(secondResult.task(":unMock").getOutcome(), TaskOutcome.SUCCESS);
+    }
+
+    @Test
+    public void unMockTaskIsNotUpToDateIfOutputDirectoryIsDeleted() {
+        BuildResult firstResult = newGradleRunner().build();
+
+        assertSame(firstResult.task(":unMock").getOutcome(), TaskOutcome.SUCCESS);
+
+        GFileUtils.deleteDirectory(new File(testProjectDir.getRoot(), "build/intermediates/unmock_work"));
+
+        BuildResult secondResult = newGradleRunner().build();
+
+        assertSame(secondResult.task(":unMock").getOutcome(), TaskOutcome.SUCCESS);
+    }
+
+    @Test
+    public void unMockTaskIsNotUpToDateIfOutputJarIsDeleted() {
+        BuildResult firstResult = newGradleRunner().build();
+
+        assertSame(firstResult.task(":unMock").getOutcome(), TaskOutcome.SUCCESS);
+
+        GFileUtils.forceDelete(new File(testProjectDir.getRoot(),
+                                        "build/intermediates/unmocked-android" + testProjectDir.getRoot()
+                                                                                               .getName() + ".jar"));
+
+        BuildResult secondResult = newGradleRunner().build();
+
+        assertSame(secondResult.task(":unMock").getOutcome(), TaskOutcome.SUCCESS);
+    }
+
+    @Test
+    public void unMockTaskIsLoadedFromCacheWhenUsingBuildCache() {
+        BuildResult firstResult = newGradleRunner().withArguments("--build-cache", "unMock").build();
+
+        assertSame(firstResult.task(":unMock").getOutcome(), TaskOutcome.SUCCESS);
+
+        GFileUtils.deleteDirectory(new File(testProjectDir.getRoot(), "build"));
+
+        BuildResult secondResult = newGradleRunner().withArguments("--build-cache", "unMock").build();
+
+        assertSame(secondResult.task(":unMock").getOutcome(), TaskOutcome.FROM_CACHE);
+    }
+
+    private GradleRunner newGradleRunner() {
+        return GradleRunner.create()
+                           .withProjectDir(testProjectDir.getRoot())
+                           .withPluginClasspath()
+                           .withArguments("unMock");
+    }
+}


### PR DESCRIPTION
This adds a new UnMockTask class which defines the correct input
and output properties needed for Gradle to do proper up-to-date
checking on the task. It also allows Gradle to handle any file
downloads for dependent jars rather than trying to handle this
manually in ProcessRealAndroidJar.

In order to test that the caching logic is working correctly, add
a dependency on Gradle TestKit and java-gradle-plugin so that unit
tests can be written in the plugin project directly.

Fixes #46 and #47