### PR TITLE
Solves issue #51

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.3.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/buildSrc/src/main/groovy/de/mobilej/unmock/UnMockPlugin.groovy
+++ b/buildSrc/src/main/groovy/de/mobilej/unmock/UnMockPlugin.groovy
@@ -50,14 +50,10 @@ class UnMockPlugin implements Plugin<Project> {
         def isApp = project.plugins.findPlugin('com.android.application')
 
         if(isLib || isApp) {
-            def mainVariants
-            if (isLib) {
-                mainVariants = project.android.libraryVariants
-            } else {
-                mainVariants = project.android.applicationVariants
-            }
+            def mainVariants = project.android.unitTestVariants
 
             mainVariants.all { variant ->
+                System.out.println("variantName:" + variant.name)
                  def unMockTask = project.tasks.register("unMock${variant.name.capitalize()}", UnMockTask.class) {
                      allAndroid = project.unMock.allAndroid
 

--- a/buildSrc/src/main/groovy/de/mobilej/unmock/UnMockPlugin.groovy
+++ b/buildSrc/src/main/groovy/de/mobilej/unmock/UnMockPlugin.groovy
@@ -53,7 +53,7 @@ class UnMockPlugin implements Plugin<Project> {
         //create a unique dependency for all tests variants
         //this dependency is provided by the unique task: when gradle will need it, it will run the task,
         // prior to compilation
-        def outputJarDependency = project.files(outputJarPath).builtBy("unMockAndroid")
+        def outputJarDependency = project.files(outputJarPath).builtBy("unMock")
         //all test variants compile task use the dependency (because it's test implementation)
         try {
             project.dependencies.add("testImplementation", outputJarDependency)

--- a/buildSrc/src/test/java/de/mobilej/UnMockTaskTest.java
+++ b/buildSrc/src/test/java/de/mobilej/UnMockTaskTest.java
@@ -124,7 +124,7 @@ public class UnMockTaskTest {
     @Test
     public void canAddTaskToProject() {
         Project project = ProjectBuilder.builder().build();
-        Task task = project.getTasks().create("unMock", UnMockTask.class);
+        Task task = project.getTasks().create("unMockAndroid", UnMockTask.class);
         assertNotNull(task);
     }
 
@@ -132,7 +132,7 @@ public class UnMockTaskTest {
     public void unMockTaskPassesOnce() {
         BuildResult result = newGradleRunner().build();
 
-        assertSame(result.task(":unMockDebugUnitTest").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(result.task(":unMockAndroid").getOutcome(), TaskOutcome.SUCCESS);
     }
 
     @Test
@@ -140,15 +140,15 @@ public class UnMockTaskTest {
         BuildResult firstResult = newGradleRunner().build();
         BuildResult secondResult = newGradleRunner().build();
 
-        assertSame(firstResult.task(":unMockDebugUnitTest").getOutcome(), TaskOutcome.SUCCESS);
-        assertSame(secondResult.task(":unMockDebugUnitTest").getOutcome(), TaskOutcome.UP_TO_DATE);
+        assertSame(firstResult.task(":unMockAndroid").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(secondResult.task(":unMockAndroid").getOutcome(), TaskOutcome.UP_TO_DATE);
     }
 
     @Test
     public void unMockTaskIsNotUpToDateIfNewKeepClassAdded() {
         BuildResult firstResult = newGradleRunner().build();
 
-        assertSame(firstResult.task(":unMockDebugUnitTest").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(firstResult.task(":unMockAndroid").getOutcome(), TaskOutcome.SUCCESS);
 
         writeFile(BUILD_GRADLE_CONTENTS
                       + "unMock {\n"
@@ -158,27 +158,27 @@ public class UnMockTaskTest {
 
         BuildResult secondResult = newGradleRunner().build();
 
-        assertSame(secondResult.task(":unMockDebugUnitTest").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(secondResult.task(":unMockAndroid").getOutcome(), TaskOutcome.SUCCESS);
     }
 
     @Test
     public void unMockTaskIsNotUpToDateIfOutputDirectoryIsDeleted() {
         BuildResult firstResult = newGradleRunner().build();
 
-        assertSame(firstResult.task(":unMockDebugUnitTest").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(firstResult.task(":unMockAndroid").getOutcome(), TaskOutcome.SUCCESS);
 
         GFileUtils.deleteDirectory(new File(testProjectDir.getRoot(), "build/intermediates/unmock_work"));
 
         BuildResult secondResult = newGradleRunner().build();
 
-        assertSame(secondResult.task(":unMockDebugUnitTest").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(secondResult.task(":unMockAndroid").getOutcome(), TaskOutcome.SUCCESS);
     }
 
     @Test
     public void unMockTaskIsNotUpToDateIfOutputJarIsDeleted() {
         BuildResult firstResult = newGradleRunner().build();
 
-        assertSame(firstResult.task(":unMockDebugUnitTest").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(firstResult.task(":unMockAndroid").getOutcome(), TaskOutcome.SUCCESS);
 
         GFileUtils.forceDelete(new File(testProjectDir.getRoot(),
                                         "build/intermediates/unmocked-android" + testProjectDir.getRoot()
@@ -186,26 +186,26 @@ public class UnMockTaskTest {
 
         BuildResult secondResult = newGradleRunner().build();
 
-        assertSame(secondResult.task(":unMockDebugUnitTest").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(secondResult.task(":unMockAndroid").getOutcome(), TaskOutcome.SUCCESS);
     }
 
     @Test
     public void unMockTaskIsLoadedFromCacheWhenUsingBuildCache() {
-        BuildResult firstResult = newGradleRunner().withArguments("--build-cache", "unMockDebug").build();
+        BuildResult firstResult = newGradleRunner().withArguments("--build-cache", "unMockAndroid").build();
 
-        assertSame(firstResult.task(":unMockDebugUnitTest").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(firstResult.task(":unMockAndroid").getOutcome(), TaskOutcome.SUCCESS);
 
         GFileUtils.deleteDirectory(new File(testProjectDir.getRoot(), "build"));
 
-        BuildResult secondResult = newGradleRunner().withArguments("--build-cache", "unMockDebug").build();
+        BuildResult secondResult = newGradleRunner().withArguments("--build-cache", "unMockAndroid").build();
 
-        assertSame(secondResult.task(":unMockDebugUnitTest").getOutcome(), TaskOutcome.FROM_CACHE);
+        assertSame(secondResult.task(":unMockAndroid").getOutcome(), TaskOutcome.FROM_CACHE);
     }
 
     private GradleRunner newGradleRunner() {
         return GradleRunner.create()
                            .withProjectDir(testProjectDir.getRoot())
                            .withPluginClasspath()
-                           .withArguments("unMockDebugUnitTest");
+                           .withArguments("unMockAndroid").forwardOutput();
     }
 }

--- a/buildSrc/src/test/java/de/mobilej/UnMockTaskTest.java
+++ b/buildSrc/src/test/java/de/mobilej/UnMockTaskTest.java
@@ -124,7 +124,7 @@ public class UnMockTaskTest {
     @Test
     public void canAddTaskToProject() {
         Project project = ProjectBuilder.builder().build();
-        Task task = project.getTasks().create("unMockAndroid", UnMockTask.class);
+        Task task = project.getTasks().create("unMock", UnMockTask.class);
         assertNotNull(task);
     }
 
@@ -132,7 +132,7 @@ public class UnMockTaskTest {
     public void unMockTaskPassesOnce() {
         BuildResult result = newGradleRunner().build();
 
-        assertSame(result.task(":unMockAndroid").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(result.task(":unMock").getOutcome(), TaskOutcome.SUCCESS);
     }
 
     @Test
@@ -140,15 +140,15 @@ public class UnMockTaskTest {
         BuildResult firstResult = newGradleRunner().build();
         BuildResult secondResult = newGradleRunner().build();
 
-        assertSame(firstResult.task(":unMockAndroid").getOutcome(), TaskOutcome.SUCCESS);
-        assertSame(secondResult.task(":unMockAndroid").getOutcome(), TaskOutcome.UP_TO_DATE);
+        assertSame(firstResult.task(":unMock").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(secondResult.task(":unMock").getOutcome(), TaskOutcome.UP_TO_DATE);
     }
 
     @Test
     public void unMockTaskIsNotUpToDateIfNewKeepClassAdded() {
         BuildResult firstResult = newGradleRunner().build();
 
-        assertSame(firstResult.task(":unMockAndroid").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(firstResult.task(":unMock").getOutcome(), TaskOutcome.SUCCESS);
 
         writeFile(BUILD_GRADLE_CONTENTS
                       + "unMock {\n"
@@ -158,27 +158,27 @@ public class UnMockTaskTest {
 
         BuildResult secondResult = newGradleRunner().build();
 
-        assertSame(secondResult.task(":unMockAndroid").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(secondResult.task(":unMock").getOutcome(), TaskOutcome.SUCCESS);
     }
 
     @Test
     public void unMockTaskIsNotUpToDateIfOutputDirectoryIsDeleted() {
         BuildResult firstResult = newGradleRunner().build();
 
-        assertSame(firstResult.task(":unMockAndroid").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(firstResult.task(":unMock").getOutcome(), TaskOutcome.SUCCESS);
 
         GFileUtils.deleteDirectory(new File(testProjectDir.getRoot(), "build/intermediates/unmock_work"));
 
         BuildResult secondResult = newGradleRunner().build();
 
-        assertSame(secondResult.task(":unMockAndroid").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(secondResult.task(":unMock").getOutcome(), TaskOutcome.SUCCESS);
     }
 
     @Test
     public void unMockTaskIsNotUpToDateIfOutputJarIsDeleted() {
         BuildResult firstResult = newGradleRunner().build();
 
-        assertSame(firstResult.task(":unMockAndroid").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(firstResult.task(":unMock").getOutcome(), TaskOutcome.SUCCESS);
 
         GFileUtils.forceDelete(new File(testProjectDir.getRoot(),
                                         "build/intermediates/unmocked-android" + testProjectDir.getRoot()
@@ -186,26 +186,27 @@ public class UnMockTaskTest {
 
         BuildResult secondResult = newGradleRunner().build();
 
-        assertSame(secondResult.task(":unMockAndroid").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(secondResult.task(":unMock").getOutcome(), TaskOutcome.SUCCESS);
     }
 
     @Test
     public void unMockTaskIsLoadedFromCacheWhenUsingBuildCache() {
-        BuildResult firstResult = newGradleRunner().withArguments("--build-cache", "unMockAndroid").build();
+        BuildResult firstResult = newGradleRunner().withArguments("--build-cache", "unMock").build();
 
-        assertSame(firstResult.task(":unMockAndroid").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(firstResult.task(":unMock").getOutcome(), TaskOutcome.SUCCESS);
 
         GFileUtils.deleteDirectory(new File(testProjectDir.getRoot(), "build"));
 
-        BuildResult secondResult = newGradleRunner().withArguments("--build-cache", "unMockAndroid").build();
+        BuildResult secondResult = newGradleRunner().withArguments("--build-cache", "unMock").build();
 
-        assertSame(secondResult.task(":unMockAndroid").getOutcome(), TaskOutcome.FROM_CACHE);
+        assertSame(secondResult.task(":unMock").getOutcome(), TaskOutcome.FROM_CACHE);
     }
 
     private GradleRunner newGradleRunner() {
         return GradleRunner.create()
+                           //.forwardOutput()
                            .withProjectDir(testProjectDir.getRoot())
                            .withPluginClasspath()
-                           .withArguments("unMockAndroid").forwardOutput();
+                           .withArguments("unMock");
     }
 }

--- a/buildSrc/src/test/java/de/mobilej/UnMockTaskTest.java
+++ b/buildSrc/src/test/java/de/mobilej/UnMockTaskTest.java
@@ -42,7 +42,16 @@ public class UnMockTaskTest {
     private File buildGradle;
 
     private static final String BUILD_GRADLE_CONTENTS = ""
+        + "buildscript {\n"
+        + "    repositories {\n"
+        + "        google()\n"
+        + "    }\n"
+        + "    dependencies {\n"
+        + "        classpath 'com.android.tools.build:gradle:3.3.0'\n"
+        + "    }\n"
+        + "}\n"
         + "plugins { id 'de.mobilej.unmock' apply false }\n"
+        + "apply plugin: 'com.android.application'\n"
         + "\n"
         + "repositories {\n"
         + "    jcenter()\n"
@@ -51,6 +60,17 @@ public class UnMockTaskTest {
         // Since we're not adding AGP as a dependency, we need to create this configuration manually for things to work
         + "configurations { testImplementation }"
         + "\n"
+        + "android {\n"
+        + "compileSdkVersion 28\n"
+        + "buildToolsVersion \"28.0.3\"\n"
+        + "    defaultConfig {\n"
+        + "        applicationId 'com.example.myapp'\n"
+        + "        minSdkVersion 15\n"
+        + "        targetSdkVersion 28\n"
+        + "        versionCode 1\n"
+        + "        versionName \"1.0\"\n"
+        + "  }\n"
+        + "}\n"
         + "apply plugin: 'de.mobilej.unmock'"
         + "\n"
         + "dependencies {\n"
@@ -112,7 +132,7 @@ public class UnMockTaskTest {
     public void unMockTaskPassesOnce() {
         BuildResult result = newGradleRunner().build();
 
-        assertSame(result.task(":unMock").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(result.task(":unMockDebug").getOutcome(), TaskOutcome.SUCCESS);
     }
 
     @Test
@@ -120,15 +140,15 @@ public class UnMockTaskTest {
         BuildResult firstResult = newGradleRunner().build();
         BuildResult secondResult = newGradleRunner().build();
 
-        assertSame(firstResult.task(":unMock").getOutcome(), TaskOutcome.SUCCESS);
-        assertSame(secondResult.task(":unMock").getOutcome(), TaskOutcome.UP_TO_DATE);
+        assertSame(firstResult.task(":unMockDebug").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(secondResult.task(":unMockDebug").getOutcome(), TaskOutcome.UP_TO_DATE);
     }
 
     @Test
     public void unMockTaskIsNotUpToDateIfNewKeepClassAdded() {
         BuildResult firstResult = newGradleRunner().build();
 
-        assertSame(firstResult.task(":unMock").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(firstResult.task(":unMockDebug").getOutcome(), TaskOutcome.SUCCESS);
 
         writeFile(BUILD_GRADLE_CONTENTS
                       + "unMock {\n"
@@ -138,27 +158,27 @@ public class UnMockTaskTest {
 
         BuildResult secondResult = newGradleRunner().build();
 
-        assertSame(secondResult.task(":unMock").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(secondResult.task(":unMockDebug").getOutcome(), TaskOutcome.SUCCESS);
     }
 
     @Test
     public void unMockTaskIsNotUpToDateIfOutputDirectoryIsDeleted() {
         BuildResult firstResult = newGradleRunner().build();
 
-        assertSame(firstResult.task(":unMock").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(firstResult.task(":unMockDebug").getOutcome(), TaskOutcome.SUCCESS);
 
         GFileUtils.deleteDirectory(new File(testProjectDir.getRoot(), "build/intermediates/unmock_work"));
 
         BuildResult secondResult = newGradleRunner().build();
 
-        assertSame(secondResult.task(":unMock").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(secondResult.task(":unMockDebug").getOutcome(), TaskOutcome.SUCCESS);
     }
 
     @Test
     public void unMockTaskIsNotUpToDateIfOutputJarIsDeleted() {
         BuildResult firstResult = newGradleRunner().build();
 
-        assertSame(firstResult.task(":unMock").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(firstResult.task(":unMockDebug").getOutcome(), TaskOutcome.SUCCESS);
 
         GFileUtils.forceDelete(new File(testProjectDir.getRoot(),
                                         "build/intermediates/unmocked-android" + testProjectDir.getRoot()
@@ -166,26 +186,26 @@ public class UnMockTaskTest {
 
         BuildResult secondResult = newGradleRunner().build();
 
-        assertSame(secondResult.task(":unMock").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(secondResult.task(":unMockDebug").getOutcome(), TaskOutcome.SUCCESS);
     }
 
     @Test
     public void unMockTaskIsLoadedFromCacheWhenUsingBuildCache() {
-        BuildResult firstResult = newGradleRunner().withArguments("--build-cache", "unMock").build();
+        BuildResult firstResult = newGradleRunner().withArguments("--build-cache", "unMockDebug").build();
 
-        assertSame(firstResult.task(":unMock").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(firstResult.task(":unMockDebug").getOutcome(), TaskOutcome.SUCCESS);
 
         GFileUtils.deleteDirectory(new File(testProjectDir.getRoot(), "build"));
 
-        BuildResult secondResult = newGradleRunner().withArguments("--build-cache", "unMock").build();
+        BuildResult secondResult = newGradleRunner().withArguments("--build-cache", "unMockDebug").build();
 
-        assertSame(secondResult.task(":unMock").getOutcome(), TaskOutcome.FROM_CACHE);
+        assertSame(secondResult.task(":unMockDebug").getOutcome(), TaskOutcome.FROM_CACHE);
     }
 
     private GradleRunner newGradleRunner() {
         return GradleRunner.create()
                            .withProjectDir(testProjectDir.getRoot())
                            .withPluginClasspath()
-                           .withArguments("unMock");
+                           .withArguments("unMockDebug");
     }
 }

--- a/buildSrc/src/test/java/de/mobilej/UnMockTaskTest.java
+++ b/buildSrc/src/test/java/de/mobilej/UnMockTaskTest.java
@@ -132,7 +132,7 @@ public class UnMockTaskTest {
     public void unMockTaskPassesOnce() {
         BuildResult result = newGradleRunner().build();
 
-        assertSame(result.task(":unMockDebug").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(result.task(":unMockDebugUnitTest").getOutcome(), TaskOutcome.SUCCESS);
     }
 
     @Test
@@ -140,15 +140,15 @@ public class UnMockTaskTest {
         BuildResult firstResult = newGradleRunner().build();
         BuildResult secondResult = newGradleRunner().build();
 
-        assertSame(firstResult.task(":unMockDebug").getOutcome(), TaskOutcome.SUCCESS);
-        assertSame(secondResult.task(":unMockDebug").getOutcome(), TaskOutcome.UP_TO_DATE);
+        assertSame(firstResult.task(":unMockDebugUnitTest").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(secondResult.task(":unMockDebugUnitTest").getOutcome(), TaskOutcome.UP_TO_DATE);
     }
 
     @Test
     public void unMockTaskIsNotUpToDateIfNewKeepClassAdded() {
         BuildResult firstResult = newGradleRunner().build();
 
-        assertSame(firstResult.task(":unMockDebug").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(firstResult.task(":unMockDebugUnitTest").getOutcome(), TaskOutcome.SUCCESS);
 
         writeFile(BUILD_GRADLE_CONTENTS
                       + "unMock {\n"
@@ -158,27 +158,27 @@ public class UnMockTaskTest {
 
         BuildResult secondResult = newGradleRunner().build();
 
-        assertSame(secondResult.task(":unMockDebug").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(secondResult.task(":unMockDebugUnitTest").getOutcome(), TaskOutcome.SUCCESS);
     }
 
     @Test
     public void unMockTaskIsNotUpToDateIfOutputDirectoryIsDeleted() {
         BuildResult firstResult = newGradleRunner().build();
 
-        assertSame(firstResult.task(":unMockDebug").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(firstResult.task(":unMockDebugUnitTest").getOutcome(), TaskOutcome.SUCCESS);
 
         GFileUtils.deleteDirectory(new File(testProjectDir.getRoot(), "build/intermediates/unmock_work"));
 
         BuildResult secondResult = newGradleRunner().build();
 
-        assertSame(secondResult.task(":unMockDebug").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(secondResult.task(":unMockDebugUnitTest").getOutcome(), TaskOutcome.SUCCESS);
     }
 
     @Test
     public void unMockTaskIsNotUpToDateIfOutputJarIsDeleted() {
         BuildResult firstResult = newGradleRunner().build();
 
-        assertSame(firstResult.task(":unMockDebug").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(firstResult.task(":unMockDebugUnitTest").getOutcome(), TaskOutcome.SUCCESS);
 
         GFileUtils.forceDelete(new File(testProjectDir.getRoot(),
                                         "build/intermediates/unmocked-android" + testProjectDir.getRoot()
@@ -186,26 +186,26 @@ public class UnMockTaskTest {
 
         BuildResult secondResult = newGradleRunner().build();
 
-        assertSame(secondResult.task(":unMockDebug").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(secondResult.task(":unMockDebugUnitTest").getOutcome(), TaskOutcome.SUCCESS);
     }
 
     @Test
     public void unMockTaskIsLoadedFromCacheWhenUsingBuildCache() {
         BuildResult firstResult = newGradleRunner().withArguments("--build-cache", "unMockDebug").build();
 
-        assertSame(firstResult.task(":unMockDebug").getOutcome(), TaskOutcome.SUCCESS);
+        assertSame(firstResult.task(":unMockDebugUnitTest").getOutcome(), TaskOutcome.SUCCESS);
 
         GFileUtils.deleteDirectory(new File(testProjectDir.getRoot(), "build"));
 
         BuildResult secondResult = newGradleRunner().withArguments("--build-cache", "unMockDebug").build();
 
-        assertSame(secondResult.task(":unMockDebug").getOutcome(), TaskOutcome.FROM_CACHE);
+        assertSame(secondResult.task(":unMockDebugUnitTest").getOutcome(), TaskOutcome.FROM_CACHE);
     }
 
     private GradleRunner newGradleRunner() {
         return GradleRunner.create()
                            .withProjectDir(testProjectDir.getRoot())
                            .withPluginClasspath()
-                           .withArguments("unMockDebug");
+                           .withArguments("unMockDebugUnitTest");
     }
 }


### PR DESCRIPTION
Solves issue #51  
I made all changes. Now tasks are created per variant (e.g. unMockDebugUnitTest, unmockMyBuildTypeReleaseUnitTest, etc.).

There is no afterEvaluate block anymore.

And cherry on top of the cake, as the plugin is in Groovy, it benefits from a full dynamic typing and doesn't rely on the android plugin ;) . But honnestly it would be better to have it typed, in kotlin, and depending on the plugin IMHO. 