### PR TITLE
Upgrade javassist

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -106,6 +106,6 @@ dependencies {
 
     compile 'org.javassist:javassist:3.20.0-GA'
 
-    testCompile 'junit:junit:4.12'
+    testCompile 'junit:junit:4.13'
     testCompile gradleTestKit()
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -104,7 +104,7 @@ dependencies {
     compile gradleApi()
     compile localGroovy()
 
-    compile 'org.javassist:javassist:3.20.0-GA'
+    compile 'org.javassist:javassist:3.26.0-GA'
 
     testCompile 'junit:junit:4.13'
     testCompile gradleTestKit()

--- a/buildSrc/src/main/java/de/mobilej/ProcessRealAndroidJar.java
+++ b/buildSrc/src/main/java/de/mobilej/ProcessRealAndroidJar.java
@@ -91,6 +91,8 @@ public class ProcessRealAndroidJar {
 
         createHelperClasses(outputDir, pool);
 
+        List<CtClass> clazzes = new ArrayList<>();
+
         for (String clazzName : clazzNames) {
             CtClass clazz = pool.get(clazzName);
 
@@ -140,6 +142,13 @@ public class ProcessRealAndroidJar {
                 logger.error("-> unable to process", e);
             }
 
+            clazzes.add(clazz);
+        }
+
+        // Write the files after all CtClass objects have been modified, otherwise Javassist
+        // doesn't allow modifying a nested class when the outer class has been written already
+        // (it freezes the outer class again).
+        for (CtClass clazz : clazzes) {
             clazz.writeFile(outputDir.getAbsolutePath());
         }
 

--- a/examplelib/src/test/java/de/mobilej/examplelib/SimpleTest.java
+++ b/examplelib/src/test/java/de/mobilej/examplelib/SimpleTest.java
@@ -157,6 +157,6 @@ public class SimpleTest {
         // formatting
         dtIntervalFmt.format(dtInterval, str, pos);
 
-        assertEquals("2 – 3 January 1970", str.toString());
+        assertEquals("1 – 2 January 1970", str.toString());
     }
 }


### PR DESCRIPTION
I wanted to use the plugin in our project. We have our own Gradle plugins as part of the `buildSrc` folder and they use Javassist with a newer version as well. This forces Gradle to use the latest version. There seems to be a behavior change in the library that causes failures in the unmock plugin. It's easy to reproduce by just bumping the version, the error is similar to this one: https://github.com/jboss-javassist/javassist/issues/56 This PR upgrades Javassist to the latest version and fixes the bug. 