### PR TITLE
Allow unmocked classes in any variant

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -33,6 +33,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }
@@ -105,6 +106,7 @@ dependencies {
     compile localGroovy()
 
     compile 'org.javassist:javassist:3.26.0-GA'
+    compile 'com.android.tools.build:gradle:3.3.0'
 
     testCompile 'junit:junit:4.13'
     testCompile gradleTestKit()


### PR DESCRIPTION
Previously unmocked classes were added to the testImplementation
configuration of each module that needed them. This leads to
duplicate work being done by every module that has unit tests.
Now there can be a single unmocking module that is included by
all other modules.

Usage:
```
unMock {
    includeInVariants android.libraryVariants
}
```