### PR TITLE
Fix plugin crashing when applied without jar

### DIFF
--- a/buildSrc/src/main/groovy/de/mobilej/unmock/UnMockPlugin.groovy
+++ b/buildSrc/src/main/groovy/de/mobilej/unmock/UnMockPlugin.groovy
@@ -35,8 +35,10 @@ class UnMockPlugin implements Plugin<Project> {
                 attribute(unmockProcessedAttribute)
             }
 
-            artifactTypes.getByName("jar") {
-                attributes.attribute(unmockProcessedAttribute, false)
+            if (artifactTypes.getNames().contains("jar")) {
+                artifactTypes.getByName("jar") {
+                    attributes.attribute(unmockProcessedAttribute, false)
+                }
             }
 
             registerTransform(UnMockTransform) {


### PR DESCRIPTION
Currently, when applying unmock plugin without java or android plugin, it will crash:

```
org.gradle.api.plugins.InvalidPluginException: An exception occurred applying plugin request [id: 'de.mobilej.unmock']
	at org.gradle.plugin.use.internal.DefaultPluginRequestApplicator.exceptionOccurred(DefaultPluginRequestApplicator.java:179)
...
Caused by: org.gradle.api.internal.plugins.PluginApplicationException: Failed to apply plugin 'de.mobilej.unmock'.
	at org.gradle.api.internal.plugins.DefaultPluginManager.doApply(DefaultPluginManager.java:176)
	at org.gradle.api.internal.plugins.DefaultPluginManager.apply(DefaultPluginManager.java:139)
	at org.gradle.plugin.use.resolve.internal.ClassPathPluginResolution.applyTo(ClassPathPluginResolution.java:50)
	at org.gradle.plugin.use.internal.DefaultPluginRequestApplicator$ApplyAction.apply(DefaultPluginRequestApplicator.java:156)
	... 169 more
Caused by: org.gradle.api.UnknownDomainObjectException: ArtifactTypeDefinition with name 'jar' not found.
	at org.gradle.api.internal.DefaultNamedDomainObjectCollection.createNotFoundException(DefaultNamedDomainObjectCollection.java:529)
	at org.gradle.api.internal.DefaultNamedDomainObjectCollection.getByName(DefaultNamedDomainObjectCollection.java:358)
	at org.gradle.api.internal.DefaultNamedDomainObjectCollection.getByName(DefaultNamedDomainObjectCollection.java:371)
	at org.gradle.api.internal.DefaultNamedDomainObjectCollection.getByName(DefaultNamedDomainObjectCollection.java:365)
	at org.gradle.api.NamedDomainObjectCollection$getByName.call(Unknown Source)
	at de.mobilej.unmock.UnMockPlugin$_apply_closure1.doCall$original(UnMockPlugin.groovy:38)
	at de.mobilej.unmock.UnMockPlugin$_apply_closure1.doCall(UnMockPlugin.groovy)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at org.gradle.util.internal.ClosureBackedAction.execute(ClosureBackedAction.java:73)
	at org.gradle.util.internal.ConfigureUtil.configureTarget(ConfigureUtil.java:166)
	at org.gradle.util.internal.ConfigureUtil.configure(ConfigureUtil.java:107)
	at org.gradle.api.internal.project.DefaultProject.dependencies(DefaultProject.java:1275)
	at org.gradle.api.Project$dependencies$0.call(Unknown Source)
	at de.mobilej.unmock.UnMockPlugin.apply(UnMockPlugin.groovy:33)
	at de.mobilej.unmock.UnMockPlugin.apply(UnMockPlugin.groovy)
	at org.gradle.api.internal.plugins.ImperativeOnlyPluginTarget.applyImperative(ImperativeOnlyPluginTarget.java:54)
	at org.gradle.api.internal.plugins.RuleBasedPluginTarget.applyImperative(RuleBasedPluginTarget.java:51)
	at org.gradle.api.internal.plugins.ModelDefaultsApplyingPluginTarget.applyImperative(ModelDefaultsApplyingPluginTarget.java:46)
	at org.gradle.api.internal.plugins.DefaultPluginManager.addPlugin(DefaultPluginManager.java:190)
	at org.gradle.api.internal.plugins.DefaultPluginManager.access$100(DefaultPluginManager.java:54)
	at org.gradle.api.internal.plugins.DefaultPluginManager$AddPluginBuildOperation.run(DefaultPluginManager.java:288)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute(DefaultBuildOperationRunner.java:29)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute(DefaultBuildOperationRunner.java:26)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:166)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.run(DefaultBuildOperationRunner.java:47)
	at org.gradle.api.internal.plugins.DefaultPluginManager.lambda$doApply$0(DefaultPluginManager.java:170)
	at org.gradle.internal.code.DefaultUserCodeApplicationContext.apply(DefaultUserCodeApplicationContext.java:44)
	at org.gradle.api.internal.plugins.DefaultPluginManager.doApply(DefaultPluginManager.java:169)
	... 172 more
```

this is mostly a problem, when applying plugin to kts via plugins block:

```
plugins {
   id("de.mobilej.unmock")
}
```

with this, Gradle will create an empty project and apply all plugins to generate project accessors. This dummy project will not have `jar` available, which will crash gradle compilation.

This PR fixes that.