### PR TITLE
fix ConfigurableFileCollections error

### DIFF
--- a/buildSrc/src/main/groovy/de/mobilej/unmock/UnMockPlugin.groovy
+++ b/buildSrc/src/main/groovy/de/mobilej/unmock/UnMockPlugin.groovy
@@ -20,6 +20,7 @@ import de.mobilej.UnMockTransform
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.attributes.Attribute
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.tasks.testing.Test
 
 class UnMockPlugin implements Plugin<Project> {
@@ -69,7 +70,14 @@ class UnMockPlugin implements Plugin<Project> {
         project.afterEvaluate {
             project.tasks.configureEach { task ->
                 if (task.name.contains("UnitTest") && task.hasProperty("classpath")) {
-                    task.classpath = unmockFiles + task.classpath
+                    // Some test tasks (such as when using Detekt), expose classpath as
+                    // ConfigurableFileCollection. This one does not support adding new files
+                    // with "plus". You have to use "from" method.
+                    if (task.classpath instanceof ConfigurableFileCollection) {
+                        task.classpath.from(unmockFiles)
+                    } else {
+                        task.classpath = unmockFiles + task.classpath
+                    }
                 }
             }
         }

--- a/buildSrc/src/main/groovy/de/mobilej/unmock/UnMockPlugin.groovy
+++ b/buildSrc/src/main/groovy/de/mobilej/unmock/UnMockPlugin.groovy
@@ -16,6 +16,7 @@
 
 package de.mobilej.unmock
 
+import com.android.build.gradle.tasks.factory.AndroidUnitTest
 import de.mobilej.UnMockTransform
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -68,17 +69,8 @@ class UnMockPlugin implements Plugin<Project> {
         def unmockFiles = project.files(unmockConfiguration)
 
         project.afterEvaluate {
-            project.tasks.configureEach { task ->
-                if (task.name.contains("UnitTest") && task.hasProperty("classpath")) {
-                    // Some test tasks (such as when using Detekt), expose classpath as
-                    // ConfigurableFileCollection. This one does not support adding new files
-                    // with "plus". You have to use "from" method.
-                    if (task.classpath instanceof ConfigurableFileCollection) {
-                        task.classpath.from(unmockFiles)
-                    } else {
-                        task.classpath = unmockFiles + task.classpath
-                    }
-                }
+            project.tasks.withType(AndroidUnitTest.class).configureEach { task ->
+                task.classpath = unmockFiles + task.classpath
             }
         }
     }

--- a/buildSrc/src/main/groovy/de/mobilej/unmock/UnMockPlugin.groovy
+++ b/buildSrc/src/main/groovy/de/mobilej/unmock/UnMockPlugin.groovy
@@ -21,8 +21,6 @@ import de.mobilej.UnMockTransform
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.attributes.Attribute
-import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.tasks.testing.Test
 
 class UnMockPlugin implements Plugin<Project> {
     void apply(Project project) {


### PR DESCRIPTION
I'm not sure if there is a better way to fix this, at the moment I have only added a special handling to use `.from()` to add stuff to the classpath instead of the `+` operator, when `ConfigurableFileCollection` is detected.

This fixes #91.

