### PR TITLE
Downgrade agp version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:9.2.1'
+        classpath 'com.android.tools.build:gradle:9.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -98,7 +98,7 @@ dependencies {
     implementation localGroovy()
 
     implementation 'org.javassist:javassist:3.27.0-GA'
-    implementation 'com.android.tools.build:gradle:9.2.1'
+    implementation 'com.android.tools.build:gradle:9.0.1'
 
     testImplementation 'junit:junit:4.13'
     testImplementation gradleTestKit()


### PR DESCRIPTION
Previous release bumps AGP all the way to the `9.2.1`. This is pretty big jump and not everyone is ready to use 9.2.1 yet - most notably [IntelliJ still does not work with anything above 9.0](https://youtrack.jetbrains.com/issue/IDEA-390133/Support-AGP-9.1)

This PR drops the AGP version back down to the 9.x.x. As far as I can tell, this should not cause any regressions.